### PR TITLE
Returns 404 on invalid pin id

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "winston": "^2.2.0"
   },
   "devDependencies": {
+    "chai": "^3.5.0",
     "jshint": "^2.9.2",
     "mocha": "^2.5.3",
     "request": "^2.72.0"

--- a/src/services/pin/hooks/index.js
+++ b/src/services/pin/hooks/index.js
@@ -7,6 +7,7 @@ const hooks = require('feathers-hooks');
 const auth = require('feathers-authentication').hooks;
 const stormpath = require('express-stormpath');
 const errors = require('feathers-errors');
+const mongoose = require('mongoose');
 
 function restrictToOwnerOfPin() {
   return function(hook) {
@@ -21,10 +22,21 @@ function restrictToOwnerOfPin() {
   };
 }
 
+function validateObjectId() {
+  return function(hook) {
+    const id = hook.id;
+    if (id && !mongoose.Types.ObjectId.isValid(id)) {
+      throw new errors.NotFound(`No record found for id '${id}'`);
+    }
+  }
+}
+
 exports.before = {
   all: [globalHooks.swapLatLong()],
   find: [],
-  get: [],
+  get: [
+    validateObjectId()
+  ],
   create: [
     auth.verifyToken(),
     auth.populateUser(),

--- a/src/services/pin/index.js
+++ b/src/services/pin/index.js
@@ -2,10 +2,6 @@
 
 const pin = require('./pin-model');
 const hooks = require('./hooks');
-
-const Promise = require('bluebird');
-const errors = require('feathers-errors');
-const stormpath = require('express-stormpath');
 const service = require('feathers-mongoose');
 
 module.exports = function() {

--- a/test/services/pin/index.test.js
+++ b/test/services/pin/index.test.js
@@ -1,10 +1,32 @@
 'use strict';
 
+const expect = require('chai').expect;
 const assert = require('assert');
+const errors = require('feathers-errors');
+const mongoose = require('mongoose');
 const app = require('../../../src/app');
 
+const pins = app.service('pins');
+
 describe('pin service', function() {
+
   it('registered the pins service', () => {
-    assert.ok(app.service('pins'));
+    assert.ok(pins);
+  });
+
+  describe('GET', function() {
+    it('returns 404 Not Found when id is not ObjectId', function(done) {
+      const id = '1234';
+      expect(mongoose.Types.ObjectId.isValid(id)).to.equal(false);
+
+      pins.get('1234', {})
+      .then(() => done(new Error('Should not be successful')))
+      .catch(error => {
+        expect(error.code).to.equal(404);
+        expect(error.name).to.equal('NotFound');
+        expect(error.message).to.equal('No record found for id \'1234\'');
+        done();
+      });
+    });
   });
 });


### PR DESCRIPTION
This PR is for #18.

If pin id is an invalid ObjectID, it returns `400 BadRequest` with `Cast to ObjectId failed` which is propagated from Mongoose.

This PR makes it return 404 NotFound instead.
