### PR TITLE
Separate bulk upload out to another service class

### DIFF
--- a/src/services/photo/index.js
+++ b/src/services/photo/index.js
@@ -194,18 +194,11 @@ class PhotosService {
 
 class UploadPhotoFromUrlService {
   create(data, params) {
-    var photoUrls = [];
-
-    if (Array.isArray(data.urls)) {
-      photoUrls = data;
-      return Promise.reject(new errors.NotImplemented('Array is not supported yet'));
-    } else {
-      photoUrls.push(data.urls);
+    if (!data.url) {
+      return Promise.reject(new errors.BadRequest('No URL provided'));
     }
 
-    const url = photoUrls[0];
-
-    return uploadToGCSByUrl(url)
+    return uploadToGCSByUrl(data.url)
       .then((file) => {
         return savePhotoMetadata(file);
       })
@@ -215,6 +208,12 @@ class UploadPhotoFromUrlService {
       .catch((error) => {
         return Promise.reject(error);
       });
+  }
+}
+
+class BulkUploadPhotosFromUrlsService {
+  create(data, params) {
+    return Promise.reject(new errors.NotImplemented('Bulk upload is not implemented'));
   }
 }
 
@@ -245,6 +244,8 @@ module.exports = function(){
   app.use('/photos', prepareMultipart, attachFileToFeathers, new PhotosService());
 
   // This service receives image url. Then, it downloads and stores image for you.
-  // TODO(A): support downloading multiple urls
   app.use('/photos/upload_from_url', new UploadPhotoFromUrlService());
+
+  // TODO(A): support downloading multiple urls
+  app.use('/photos/bulk_upload_from_urls', new BulkUploadPhotosFromUrlsService());
 };

--- a/src/services/photo/index.js
+++ b/src/services/photo/index.js
@@ -239,13 +239,71 @@ function attachFileToFeathers(req, res, next) {
 
 module.exports = function(){
   const app = this;
+
   //TODO(A): Need id and need to support multiple photos uplaod
   //TODO(A): Also need to support photo url and download it instead of 3rd party app
   app.use('/photos', prepareMultipart, attachFileToFeathers, new PhotosService());
 
+  /**
+   * @api {post} /photos/upload_from_url Upload from URL
+   * @apiDescription Download a photo from a provided URL and upload it for you.
+   * @apiVersion 0.1.0
+   * @apiName PostPhotosUploadFromUrl
+   * @apiGroup Photos
+   *
+   * @apiParam {String} url Photo URL to be uploaded
+   *
+   * @apiSuccess (Created 201) {String} id Photo ID.
+   * @apiSuccess (Created 201) {String} url Photo URL.
+   * @apiSuccess (Created 201) {String} mimetype MIME type.
+   * @apiSuccess (Created 201) {Number} size File size (bytes).
+
+   * @apiSuccessExample Success-Response:
+   *    HTTP/1.1 201 Created
+   *    {
+   *      "id": "578fafba3855de9d00dc3c61",
+   *      "url": "https://storage.googleapis.com/you-pin.appspot.com/1469034415861_hello.png",
+   *      "mimetype": "image/png",
+   *      "size": 138890
+   *    }
+   */
   // This service receives image url. Then, it downloads and stores image for you.
   app.use('/photos/upload_from_url', new UploadPhotoFromUrlService());
 
+  /**
+   * @api {post} /photos/bulk_upload_from_urls Bulk upload from multiple URLs
+   * @apiDescription Download multple photos from provided URLs and upload them for you.
+   * @apiVersion 0.1.0
+   * @apiName PostPhotosBulkUploadFromUrls
+   * @apiGroup Photos
+   *
+   * @apiParam {String[]} urls Array of photo URLs to be uploaded
+   *
+   * @apiSuccess (Created 201) {Object[]} photos Array of photo metadata
+   * @apiSuccess (Created 201) {String} photos.id Photo ID.
+   * @apiSuccess (Created 201) {String} photos.url Photo URL.
+   * @apiSuccess (Created 201) {String} photos.mimetype MIME type.
+   * @apiSuccess (Created 201) {Number} photos.size File size (bytes).
+
+   * @apiSuccessExample Success-Response:
+   *    HTTP/1.1 201 Created
+   *    {
+   *      "urls": [
+   *        {
+   *          "id": "578fafba3855de9d00dc3c61",
+   *          "url": "https://storage.googleapis.com/you-pin.appspot.com/1469034415861_hello.png",
+   *          "mimetype": "image/png",
+   *          "size": 138890
+   *        },
+   *        {
+   *          "id": "578fafb39fi5de9d04817u87",
+   *          "url": "https://storage.googleapis.com/you-pin.appspot.com/9069039183882_world.png",
+   *          "mimetype": "image/png",
+   *          "size": 151281
+   *        }
+   *      ]
+   *    }
+   */
   // TODO(A): support downloading multiple urls
   app.use('/photos/bulk_upload_from_urls', new BulkUploadPhotosFromUrlsService());
 };


### PR DESCRIPTION
Separate bulk upload from single upload

We'll have 2 endpoints
1) Upload single url

```
POST /photos/upload_from_url
Body { "url": <url> }
```

Note: Change `urls` from previous version to `url`.

2) Bulk upload multiple urls

```
POST /photos/bulk_upload_from_urls
Body { "urls": [<url1>, <url2>, ...] }
```

Endpoint 2) will be implemented soon

UPDATE: Endpoint 2) has been implemented
