### PR TITLE
Fix node_modules lost in docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
-FROM mhart/alpine-node:6
+FROM mhart/alpine-node:6.3
 
 MAINTAINER YouPin Team <dev@youpin.city>
 
 RUN apk add -U libc6-compat
-COPY package.json /src/package.json
-RUN cd /src && npm install
+COPY package.json /code/package.json
+RUN cd /code && npm install
 
-COPY . /src
+COPY . /code
 
-WORKDIR /src
+WORKDIR /code
 
 CMD ["npm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,6 @@ services:
     build: .
     ports:
       -  "9100:9100"
-    volumes:
-      - .:/code
     depends_on:
       - mongodb
   mongodb:


### PR DESCRIPTION
The installed node_modules folder is lost by external volume mounting. So, I discard volume mounting for this image and will make another overriding config for volume mounting in another compose setting. 
