### PR TITLE
Fix parse limit and radius params to numeric

### DIFF
--- a/src/utils/number.js
+++ b/src/utils/number.js
@@ -1,0 +1,13 @@
+var isNumericString = function(n) {
+  return !isNaN(parseFloat(n)) && isFinite(n);
+}
+
+var isIntegerString = function(n) {
+  var n = parseFloat(n);
+  return Math.floor(n) === n;
+}
+
+module.exports = {
+  isNumericString: isNumericString,
+  isIntegerString: isIntegerString
+};

--- a/src/views/layout.pug
+++ b/src/views/layout.pug
@@ -3,9 +3,9 @@ html
   head
     title= title
     meta(name='viewport', content='width=device-width, initial-scale=1.0')
-    link(href='http://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css', rel='stylesheet', media='screen')
+    link(href='https://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css', rel='stylesheet', media='screen')
   body
     block content
 
-  script(src='http://code.jquery.com/jquery.js')
-  script(src='http://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/js/bootstrap.min.js')
+  script(src='https://code.jquery.com/jquery.js')
+  script(src='https://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/js/bootstrap.min.js')

--- a/test/services/searchnearby/index.test.js
+++ b/test/services/searchnearby/index.test.js
@@ -53,7 +53,7 @@ describe('searchnearby service', () => {
     expect(app.service('searchnearby')).to.be.ok();
   });
 
-  it('returns coordinates in [lat, long] format', () => {
+  it('returns coordinates in [lat, long] format', (done) => {
     const pin = {
       detail: casual.text,
       owner: '579334c75563625d6281b6f1', // adminUser ObjectId
@@ -71,12 +71,104 @@ describe('searchnearby service', () => {
         .expect(200)
         .then((res) => {
           if (!res || !res.body.data || res.body.data.length <= 0) {
-            throw new Error('No data return');
+            return done(new Error('No data return'));
           }
 
           const foundCoordinates = res.body.data[0].location.coordinates;
           expect(foundCoordinates).to.deep.equal([13.730537951109, 100.56983534303]);
+
+          done();
         });
     });
+  });
+
+  it('limits a number of results', (done) => {
+    const pin1 = {
+      detail: casual.text,
+      owner: '579334c75563625d6281b6f1', // adminUser ObjectId
+      provider: '579334c75563625d6281b6f1', // adminUser ObjectId
+      location: {
+        coordinates: [100.56983534303, 13.730537951109],
+      },
+    };
+    const pin2 = {
+      detail: casual.text,
+      owner: '579334c75563625d6281b6f1', // adminUser ObjectId
+      provider: '579334c75563625d6281b6f1', // adminUser ObjectId
+      location: {
+        coordinates: [100.56983534303, 13.730537951109],
+      },
+    }
+    const pin3 = {
+      detail: casual.text,
+      owner: '579334c75563625d6281b6f1', // adminUser ObjectId
+      provider: '579334c75563625d6281b6f1', // adminUser ObjectId
+      location: {
+        coordinates: [100.56983534303, 13.730537951109],
+      },
+    };;
+    loadFixture(PinModel, pin1, () => {
+      loadFixture(PinModel, pin2, () => {
+        loadFixture(PinModel, pin3, () => {
+        return request(app)
+          // request in [lat, long] format
+          .get('/searchnearby?$center=[13.730537954909,100.56983580503]&$radius=1000&limit=2')
+          .expect(200)
+          .then((res) => {
+            if (!res || !res.body.data || res.body.data.length <= 0) {
+              return done(new Error('No data return'));
+            }
+
+            expect(res.body.data.length).to.equal(2);
+            done();
+          });
+        });
+      });
+    });
+  });
+
+  it('does not allow limit as a string', (done) => {
+    request(app)
+      // request in [lat, long] format
+      .get('/searchnearby?$center=[13.730537954909,100.56983580503]&$radius=1000&limit=abc')
+      .expect(400)
+      .then((res) => {
+        const error = res.body;
+        expect(error.code).to.equal(400);
+        expect(error.name).to.equal('BadRequest');
+        expect(error.message).to.equal('`limit` must be integer');
+
+        done();
+      });
+  });
+
+  it('does not allow limit as a float number', (done) => {
+    request(app)
+      // request in [lat, long] format
+      .get('/searchnearby?$center=[13.730537954909,100.56983580503]&$radius=1000&limit=1.1')
+      .expect(400)
+      .then((res) => {
+        const error = res.body;
+        expect(error.code).to.equal(400);
+        expect(error.name).to.equal('BadRequest');
+        expect(error.message).to.equal('`limit` must be integer');
+
+        done();
+      });
+  });
+
+  it('does not allow $radius as a string', (done) => {
+    request(app)
+      // request in [lat, long] format
+      .get('/searchnearby?$center=[13.730537954909,100.56983580503]&$radius=abc&limit=2')
+      .expect(400)
+      .then((res) => {
+        const error = res.body;
+        expect(error.code).to.equal(400);
+        expect(error.name).to.equal('BadRequest');
+        expect(error.message).to.equal('`$radius` must be numeric');
+
+        done();
+      });
   });
 });


### PR DESCRIPTION
In MongoDB 3.2, it does not convert string to integer. So, we need to convert it before passing to Mongoose.
