### PR TITLE
Fix removing fields of Mongoose object

### DIFF
--- a/src/services/user/hooks/index.js
+++ b/src/services/user/hooks/index.js
@@ -1,4 +1,5 @@
 const hooks = require('feathers-hooks');
+const mongooseService = require('feathers-mongoose');
 const auth = require('feathers-authentication').hooks;
 const validateObjectId = require('../../../utils/hooks/validate-object-id-hook');
 
@@ -40,7 +41,7 @@ exports.before = {
 };
 
 exports.after = {
-  all: [hooks.remove('password')],
+  all: [mongooseService.hooks.toObject({}), hooks.remove('password')],
   find: [],
   get: [],
   create: [],

--- a/test/services/user/index.test.js
+++ b/test/services/user/index.test.js
@@ -171,7 +171,8 @@ describe('user service', () => {
               expect(body).to.not.have.keys('password');
 
               done();
-            });
+            })
+            .catch(done);
         });
     });
   });
@@ -215,7 +216,8 @@ describe('user service', () => {
           expect(createdUser).to.not.contain.keys('password');
 
           done();
-        });
+        })
+        .catch(done);
     });
   });
 });


### PR DESCRIPTION
Currently, feathers-hooks cannot remove inherited fields in mongoose object. So, we need to transform the mongoose object into plain object without inherited field first. (We will drop this toObject hook when feathers supports removing inherited fields)
