### PR TITLE
Remove toObject() hook before remove hook

### DIFF
--- a/src/services/user/hooks/index.js
+++ b/src/services/user/hooks/index.js
@@ -1,5 +1,4 @@
 const hooks = require('feathers-hooks');
-const mongooseService = require('feathers-mongoose');
 const auth = require('feathers-authentication').hooks;
 const validateObjectId = require('../../../utils/hooks/validate-object-id-hook');
 
@@ -41,7 +40,7 @@ exports.before = {
 };
 
 exports.after = {
-  all: [mongooseService.hooks.toObject({}), hooks.remove('password')],
+  all: [hooks.remove('password')],
   find: [],
   get: [],
   create: [],


### PR DESCRIPTION
Now, feathers-hooks 1.5.7 use toObject() internally for mongoose object (feathersjs/feathers-hooks#92). So, we can drop toObject() hook before remove hook.

Merge #121 first.
