### PR TITLE
iss141 Create summary service and transform a query to a correct mongoose format

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "pug": "^2.0.0-beta4",
     "serve-favicon": "^2.3.0",
     "superagent": "^2.0.0",
-    "underscore": "^1.8.3",
     "uuid": "^2.0.2",
     "validator": "^5.4.0",
     "winston": "^2.2.0"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "feathers-configuration": "^0.2.3",
     "feathers-errors": "^2.2.0",
     "feathers-hooks": "^1.5.7",
-    "feathers-mongoose": "^3.5.1",
+    "feathers-mongoose": "^3.6.1",
     "feathers-nedb": "^2.3.0",
     "feathers-rest": "^1.4.2",
     "feathers-socketio": "^1.4.1",
@@ -53,6 +53,7 @@
     "pug": "^2.0.0-beta4",
     "serve-favicon": "^2.3.0",
     "superagent": "^2.0.0",
+    "underscore": "^1.8.3",
     "uuid": "^2.0.2",
     "validator": "^5.4.0",
     "winston": "^2.2.0"

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -9,6 +9,7 @@ const organization = require('./organization');
 const photo = require('./photo');
 const pin = require('./pin');
 const searchnearby = require('./searchnearby');
+const summary = require('./summary');
 const user = require('./user');
 const video = require('./video');
 
@@ -27,4 +28,5 @@ module.exports = function () { // eslint-disable-line func-names
   app.configure(searchnearby);
   app.configure(user);
   app.configure(video);
+  app.configure(summary);
 };

--- a/src/services/organization/organization-model.js
+++ b/src/services/organization/organization-model.js
@@ -8,7 +8,7 @@ const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
 
 const organizationSchema = new Schema({
-  name: { type: String, required: true },
+  name: { type: String, required: true, unique: true },
   users: [{ type: Schema.Types.ObjectId, ref: 'User' }],
   detail: { type: String },
   created_time: { type: Date, default: Date.now },

--- a/src/services/summary/hooks/index.js
+++ b/src/services/summary/hooks/index.js
@@ -1,0 +1,56 @@
+const auth = require('feathers-authentication').hooks;
+const modifySearchQuery = require('./modify-search-query');
+const ORGANIZATION_ADMIN = require('../../../constants/roles').ORGANIZATION_ADMIN;
+const SUPER_ADMIN = require('../../../constants/roles').SUPER_ADMIN;
+const validateObjectId = require('../../../utils/hooks/validate-object-id-hook');
+
+exports.before = {
+  all: [],
+  find: [
+    modifySearchQuery(),
+  ],
+  get: [validateObjectId()],
+  create: [
+    auth.verifyToken(),
+    auth.populateUser(),
+    auth.restrictToRoles({
+      roles: [SUPER_ADMIN, ORGANIZATION_ADMIN],
+      fieldName: 'role',
+    }),
+  ],
+  update: [
+    auth.verifyToken(),
+    auth.populateUser(),
+    auth.restrictToRoles({
+      roles: [SUPER_ADMIN, ORGANIZATION_ADMIN],
+      fieldName: 'role',
+    }),
+  ],
+  patch: [
+    auth.verifyToken(),
+    auth.populateUser(),
+    auth.restrictToRoles({
+      roles: [SUPER_ADMIN, ORGANIZATION_ADMIN],
+      fieldName: 'role',
+    }),
+  ],
+  remove: [
+    auth.verifyToken(),
+    auth.populateUser(),
+    auth.restrictToRoles({
+      roles: [SUPER_ADMIN, ORGANIZATION_ADMIN],
+      fieldName: 'role',
+    }),
+  ],
+};
+
+exports.after = {
+  all: [],
+  find: [],
+  get: [],
+  create: [],
+  update: [],
+  patch: [],
+  remove: [],
+};
+

--- a/src/services/summary/hooks/modify-search-query.js
+++ b/src/services/summary/hooks/modify-search-query.js
@@ -1,4 +1,4 @@
-const _ = require('underscore');
+const _ = require('lodash');
 const errors = require('feathers-errors');
 const Organization = require('../../organization/organization-model');
 
@@ -21,7 +21,6 @@ const modifySearchQuery = () => (hook) => {
   if (!_.isEmpty(date)) {
     hook.params.query.date = date; // eslint-disable-line no-param-reassign
   }
-  console.log(hook.params);
   // Return error if no organization is specified.
   if (!organizationName) {
     throw new errors.BadRequest('No `organization` specified in a query');

--- a/src/services/summary/hooks/modify-search-query.js
+++ b/src/services/summary/hooks/modify-search-query.js
@@ -1,0 +1,45 @@
+const _ = require('underscore');
+const errors = require('feathers-errors');
+const Organization = require('../../organization/organization-model');
+
+// modifySearchQuery is a before hook function to transform a summary
+// query into the correct mongoose format.
+const modifySearchQuery = () => (hook) => {
+  const startDate = hook.params.query.start_date;
+  const endDate = hook.params.query.end_date;
+  const organizationName = hook.params.query.organization;
+  const date = {};
+  // Clean slate the query.
+  hook.params.query = {}; // eslint-disable-line no-param-reassign
+  // Change start_date and end_date to mongoose query format.
+  if (startDate) {
+    date.$gte = startDate;
+  }
+  if (endDate) {
+    date.$lte = endDate;
+  }
+  if (!_.isEmpty(date)) {
+    hook.params.query.date = date; // eslint-disable-line no-param-reassign
+  }
+  console.log(hook.params);
+  // Return error if no organization is specified.
+  if (!organizationName) {
+    throw new errors.BadRequest('No `organization` specified in a query');
+  }
+  // Search for organization id since the legitimate query needs an id not a name.
+  return Organization.findOne({ name: organizationName })
+    .then(organization => {
+      if (!organization) {
+        throw new errors.NotFound(`No organization with a name called "${organizationName}".`);
+      }
+      /* eslint-disable no-param-reassign,no-underscore-dangle */
+      hook.params.query.organization = organization._id;
+      /* eslint-enable */
+      return Promise.resolve(hook);
+    })
+    .catch(err => {
+      throw new Error(err);
+    });
+};
+
+module.exports = modifySearchQuery;

--- a/src/services/summary/index.js
+++ b/src/services/summary/index.js
@@ -1,0 +1,20 @@
+const service = require('feathers-mongoose');
+const Summary = require('./summary-model');
+const hooks = require('./hooks');
+
+module.exports = function () { // eslint-disable-line func-names
+  const app = this;
+
+  const options = {
+    Model: Summary,
+    paginate: {
+      default: 5,
+      max: 25,
+    },
+  };
+
+  app.use('/summaries', service(options));
+  const summaryService = app.service('/summaries');
+  summaryService.before(hooks.before);
+  summaryService.after(hooks.after);
+};

--- a/src/services/summary/summary-model.js
+++ b/src/services/summary/summary-model.js
@@ -1,0 +1,36 @@
+const mongoose = require('mongoose');
+
+const Schema = mongoose.Schema;
+
+const byDepartmentSchema = new Schema({
+  department: { type: Schema.Types.ObjectId, ref: 'Department', required: true },
+  assigned: { type: Number },
+  processing: { type: Number },
+  resolved: { type: Number },
+});
+
+const summarySchema = new Schema({
+  organization: { type: Schema.Types.ObjectId, ref: 'Organization', required: true },
+  date: {
+    type: String,
+    required: true,
+    unique: true,
+    validate: {
+      validator: (v) => /\d{4}-\d{2}-\d{2}/.test(v),
+      message: '{VALUE} has to be in YYYY-MM-DD format!',
+    },
+  },
+  total_unverified: { type: Number },
+  total_verified: { type: Number },
+  total_assigned: { type: Number },
+  total_processing: { type: Number },
+  total_resolved: { type: Number },
+  total_rejected: { type: Number },
+  by_department: [byDepartmentSchema],
+  createdAt: { type: Date, default: Date.now },
+  updatedAt: { type: Date, default: Date.now },
+});
+
+const Model = mongoose.model('summary', summarySchema);
+
+module.exports = Model;

--- a/test/services/organization/index.test.js
+++ b/test/services/organization/index.test.js
@@ -62,7 +62,7 @@ describe('organization service', () => {
   describe('POST', () => {
     it('return 401 (unauthorized) if user is not authenticated', (done) => {
       const newOrganization = {
-        name: 'YouPin',
+        name: 'newOrganization',
         users: [superAdminUser._id, adminUser._id], // eslint-disable-line no-underscore-dangle
         detail: 'An awesome organization', // eslint-disable-line no-underscore-dangle
       };
@@ -86,7 +86,7 @@ describe('organization service', () => {
 
     it('return 201 when posting by super admin user', (done) => {
       const newOrganization = {
-        name: 'YouPin',
+        name: 'newOrganization',
         users: [superAdminUser._id, adminUser._id], // eslint-disable-line no-underscore-dangle
         detail: 'An awesome organization',
       };

--- a/test/services/summary/index.test.js
+++ b/test/services/summary/index.test.js
@@ -1,8 +1,15 @@
-const assert = require('assert');
+// Test helper functions
+const assertTestEnv = require('../../test_helper').assertTestEnv;
+const expect = require('../../test_helper').expect;
+
+// App staff
 const app = require('../../../src/app');
+
+// Exit test if NODE_ENV is not equal `test`
+assertTestEnv();
 
 describe('summary service', () => {
   it('registered the summaries service', () => {
-    assert.ok(app.service('summaries'));
+    expect(app.service('summaries')).to.be.ok();
   });
 });

--- a/test/services/summary/index.test.js
+++ b/test/services/summary/index.test.js
@@ -1,0 +1,8 @@
+const assert = require('assert');
+const app = require('../../../src/app');
+
+describe('summary service', () => {
+  it('registered the summaries service', () => {
+    assert.ok(app.service('summaries'));
+  });
+});


### PR DESCRIPTION
PR for #141  to create Restful resource for /summaries 
It is meant for storing the daily summary. The total summary of range period will then be managed by another routing called `/total_summary`

Note that we also need to create `trigger` method to recalculate and fill in each day summary. I will do it in the next PR.