### PR TITLE
Handle Facebook Login

### DIFF
--- a/config/default.template.json
+++ b/config/default.template.json
@@ -5,6 +5,8 @@
   "mongodb": "mongodb://mongodb:27017/youpin-dev",
   "public": "../public/",
   "auth": {
+    "successRedirect": "your url for success login",
+    "failureRedirect": "your url for fail login",
     "token": {
       "secret": "SECRET_AUTH_TOKEN"
     },
@@ -12,8 +14,10 @@
       "clientID": "your facebook client id",
       "clientSecret": "your facebook client secret",
       "permissions": {
+        "authType": "rerequest",
         "scope": ["public_profile","email"]
-      }
+      },
+      "profileFields": ["id", "first_name", "last_name", "email"]
     },
     "github": {
       "clientID": "your github client id",

--- a/config/production.template.json
+++ b/config/production.template.json
@@ -4,6 +4,8 @@
   "mongodb": "mongodb://mongodb:27017/youpin",
   "public": "../public/",
   "auth": {
+    "successRedirect": "your url for success login",
+    "failureRedirect": "your url for fail login",
     "token": {
       "secret": "SECRET_AUTH_TOKEN"
     },
@@ -11,8 +13,10 @@
       "clientID": "your facebook client id",
       "clientSecret": "your facebook client secret",
       "permissions": {
+        "authType": "rerequest",
         "scope": ["public_profile","email"]
-      }
+      },
+      "profileFields": ["id", "first_name", "last_name", "email"]
     },
     "github": {
       "clientID": "your github client id",

--- a/src/services/user/hooks/handle-facebook-create.js
+++ b/src/services/user/hooks/handle-facebook-create.js
@@ -1,0 +1,52 @@
+
+const handleFacebookCreate = () => (hook) => {
+  // Pass through this hook if there's no facebook data
+  if (!hook.data.facebookId
+    || !hook.data.facebook
+    || !hook.data.facebook.email
+    || (!hook.data.facebook.name
+      && !hook.data.facebook.first_name
+      && !hook.data.facebook.last_name)
+    ) {
+    return Promise.resolve(hook);
+  }
+
+  const userService = hook.app.service('/users');
+
+  // Check whether a user with same facebook email exists
+  return userService.find({ query: { email: hook.data.facebook.email } })
+    .then(results => {
+      // Handle answer in both array and object forms
+      const existingUser = results[0] || (results.data && results.data[0]);
+
+      // User properties to be created or updated
+      const data = {
+        facebookId: hook.data.facebookId,
+        email: hook.data.facebook.email,
+        name: hook.data.facebook.name ||
+          `${hook.data.facebook.first_name} ${hook.data.facebook.last_name}`,
+      };
+
+      // Patch existing user's properties
+      if (existingUser) {
+        return userService.patch(existingUser._id, data) // eslint-disable-line no-underscore-dangle
+          .then(updatedUser => {
+            // Set `hook.result` to skip the actual `create` since we updated it already
+            hook.result = updatedUser; // eslint-disable-line no-param-reassign
+
+            return Promise.resolve(hook);
+          });
+      }
+      // Create a new user if not exist
+      return userService.create(data)
+        .then(createdUser => {
+          hook.result = createdUser; // eslint-disable-line no-param-reassign
+
+          return Promise.resolve(hook);
+        })
+        .catch(err => console.error(err));
+    })
+    .catch(err => console.error(err));
+};
+
+module.exports = handleFacebookCreate;

--- a/src/services/user/hooks/index.js
+++ b/src/services/user/hooks/index.js
@@ -1,6 +1,7 @@
 const hooks = require('feathers-hooks');
 const auth = require('feathers-authentication').hooks;
 const validateObjectId = require('../../../utils/hooks/validate-object-id-hook');
+const handleFacebookCreate = require('./handle-facebook-create');
 
 exports.before = {
   all: [],
@@ -17,6 +18,7 @@ exports.before = {
     auth.restrictToOwner({ ownerField: '_id' }),
   ],
   create: [
+    handleFacebookCreate(),
     auth.hashPassword(),
   ],
   update: [

--- a/src/services/user/index.js
+++ b/src/services/user/index.js
@@ -11,6 +11,9 @@ module.exports = function () { // eslint-disable-line func-names
       default: 5,
       max: 25,
     },
+    // Convert mongoose document to plain object to fix facebook user patch service
+    // Ref: https://github.com/feathersjs/feathers-mongoose/issues/110
+    lean: true,
   };
   /* eslint-disable max-len */
   /**

--- a/src/services/user/user-model.js
+++ b/src/services/user/user-model.js
@@ -1,5 +1,6 @@
 const validator = require('validator');
 const mongoose = require('mongoose');
+const USER = require('../../constants/roles').USER;
 
 const Schema = mongoose.Schema;
 
@@ -21,7 +22,8 @@ const UserSchema = new Schema({
     unique: true,
     validate: { validator: validator.isEmail, message: '{VALUE} is not a valid email!' },
   },
-  password: { type: String, required: true },
+  password: { type: String },
+  facebookId: { type: String },
   phone: {
     type: String,
     validate: {
@@ -34,7 +36,7 @@ const UserSchema = new Schema({
   created_time: { type: Date, default: Date.now },
   updated_time: { type: Date, default: Date.now },
   customer_app_id: [Schema.Types.ObjectId],
-  role: { type: String, required: true },
+  role: { type: String, required: true, default: USER },
   owner_app_id: [Schema.Types.ObjectId],
 });
 


### PR DESCRIPTION
Close #144 

**How to use**
1. In config file (`config/default.js` or `config/production.js`), 
1.1 Set `auth.successRedirect` and `auth.failureRedirect` to URLs for success login and fail login.
1.2 Set `auth.facebook.clientId` and `auth.facebook.clientSecret` from your created facebook app.
2. Front-end implements success and failure URLs handler.
3. Bring a user to visit `http://<domain>:<port>/auth/facebook` to make Facebook Login.

**How to create Facebook app to get clientId and clientSecret**
1.  Go to https://developers.facebook.com/apps
2. Click **Add a New App** and set *Display Name* (App name), *Contact Email* (your email), and *Category* (anything), then, click **Create App ID**.
(Optional) For testing with localhost, you need to select your app name at the top left and choose **+Create Test App**
3. In Add Product page (https://developers.facebook.com/apps/<your_app_id>/add/), click **Get started** on **Facebook Login**
4. In Client OAuth Settings page (https://developers.facebook.com/apps/<your_app_id>/fb-login/), make sure that **Client OAuth Settings** and **Web OAuth Login** are set to **Yes**
5. In Settings - Basic page (https://developers.facebook.com/apps/<your_app_id>/settings/basic), 5.1 enter **localhost** in app domains
5.2 click **+Add Platform** at the bottom
5.3 select **Website** and enter **http://<domain>:<port>/** in **Site URL** (for local testing, use *localhost* for domain. Specify https if you use it.) Then, click **Save Changes**
6. Copy **Application ID** and **App Secret** to use as `auth.clientId` and `auth.clientSecret` in our config file.