### PR TITLE
Fix coding convention for Model and Schema

### DIFF
--- a/src/services/activity-log/activity-log-model.js
+++ b/src/services/activity-log/activity-log-model.js
@@ -1,7 +1,7 @@
 const mongoose = require('mongoose');
 
 const Schema = mongoose.Schema;
-const ActivityLogSchema = new Schema({
+const activityLogSchema = new Schema({
   action: { type: String }, // See 'src/constants/actions.js'
   actionType: { type: String }, // See 'src/constants/actions.js'
   changed_fields: [{ type: String }],
@@ -15,6 +15,6 @@ const ActivityLogSchema = new Schema({
   user: { type: String },
 });
 
-const ActivityLogModel = mongoose.model('ActivityLog', ActivityLogSchema);
+const ActivityLog = mongoose.model('ActivityLog', activityLogSchema);
 
-module.exports = ActivityLogModel;
+module.exports = ActivityLog;

--- a/src/services/activity-log/index.js
+++ b/src/services/activity-log/index.js
@@ -1,9 +1,9 @@
 const mongooseService = require('feathers-mongoose');
 
-const ActivityLogModel = require('./activity-log-model');
+const ActivityLog = require('./activity-log-model');
 
 module.exports = function registerActivityLogService() {
   const app = this;
 
-  app.use('/activity_logs', mongooseService({ Model: ActivityLogModel }));
+  app.use('/activity_logs', mongooseService({ Model: ActivityLog }));
 };

--- a/src/services/app3rd/app3rd-model.js
+++ b/src/services/app3rd/app3rd-model.js
@@ -10,6 +10,6 @@ const app3rdSchema = new Schema({
   updatedAt: { type: Date, default: Date.now },
 });
 
-const app3rdModel = mongoose.model('app3rd', app3rdSchema);
+const App3rd = mongoose.model('App3rd', app3rdSchema);
 
-module.exports = app3rdModel;
+module.exports = App3rd;

--- a/src/services/app3rd/index.js
+++ b/src/services/app3rd/index.js
@@ -1,13 +1,13 @@
 const service = require('feathers-mongoose');
 
-const app3rd = require('./app3rd-model');
+const App3rd = require('./app3rd-model');
 const hooks = require('./hooks');
 
 module.exports = function () { // eslint-disable-line func-names
   const app = this;
 
   const options = {
-    Model: app3rd,
+    Model: App3rd,
     paginate: {
       default: 5,
       max: 25,

--- a/src/services/department/department-model.js
+++ b/src/services/department/department-model.js
@@ -10,6 +10,6 @@ const departmentSchema = new Schema({
   updated_time: { type: Date, default: Date.now },
 });
 
-const departmentModel = mongoose.model('Department', departmentSchema);
+const Department = mongoose.model('Department', departmentSchema);
 
-module.exports = departmentModel;
+module.exports = Department;

--- a/src/services/department/index.js
+++ b/src/services/department/index.js
@@ -1,13 +1,13 @@
 const service = require('feathers-mongoose');
 
-const department = require('./department-model');
+const Department = require('./department-model');
 const hooks = require('./hooks');
 
 module.exports = function () { // eslint-disable-line func-names
   const app = this;
 
   const options = {
-    Model: department,
+    Model: Department,
     paginate: {
       default: 5,
       max: 25,

--- a/src/services/organization/index.js
+++ b/src/services/organization/index.js
@@ -1,13 +1,13 @@
 const service = require('feathers-mongoose');
 
 const hooks = require('./hooks');
-const organization = require('./organization-model');
+const Organization = require('./organization-model');
 
 module.exports = function () { // eslint-disable-line func-names
   const app = this;
 
   const options = {
-    Model: organization,
+    Model: Organization,
     paginate: {
       default: 5,
       max: 25,

--- a/src/services/organization/organization-model.js
+++ b/src/services/organization/organization-model.js
@@ -10,6 +10,6 @@ const organizationSchema = new Schema({
   updated_time: { type: Date, default: Date.now },
 });
 
-const organizationModel = mongoose.model('Organization', organizationSchema);
+const Organization = mongoose.model('Organization', organizationSchema);
 
-module.exports = organizationModel;
+module.exports = Organization;

--- a/src/services/photo/photo-model.js
+++ b/src/services/photo/photo-model.js
@@ -4,12 +4,12 @@ require('mongoose-type-url');
 const Schema = mongoose.Schema;
 const Url = mongoose.SchemaTypes.Url;
 
-const PhotoSchema = new Schema({
+const photoSchema = new Schema({
   mimetype: { type: String, required: true },
   size: { type: Number, required: true },
   url: { type: Url, required: true },
 });
 
-const PhotoModel = mongoose.model('Photo', PhotoSchema);
+const Photo = mongoose.model('Photo', photoSchema);
 
-module.exports = PhotoModel;
+module.exports = Photo;

--- a/src/services/pin/pin-model.js
+++ b/src/services/pin/pin-model.js
@@ -4,14 +4,14 @@ const UNVERIFIED = require('../../constants/pin-states').UNVERIFIED;
 
 const Schema = mongoose.Schema;
 
-const VoteSchema = new Schema({
+const voteSchema = new Schema({
   user_id: { type: Schema.Types.ObjectId, required: true, ref: 'User' },
   vote_type: { type: String, required: true },
 },
 // disable _id field
 { _id: false });
 
-const CommentSchema = new Schema({
+const commentSchema = new Schema({
   created_time: { type: Date, required: true, default: Date.now },
   detail: { type: String, required: true },
   mentions: [{ type: Schema.Types.ObjectId, ref: 'User' }],
@@ -19,16 +19,16 @@ const CommentSchema = new Schema({
   tags: [String],
   updated_time: { type: Date, required: true, default: Date.now },
   videos: [Schema.Types.ObjectId],
-  voters: [VoteSchema],
+  voters: [voteSchema],
 },
 // disable _id field
 { _id: false });
 
-const PinSchema = new Schema({
+const pinSchema = new Schema({
   assigned_department: { type: Schema.Types.ObjectId, ref: 'Departmeent' },
   assigned_user: { type: Schema.Types.ObjectId, ref: 'User' },
   categories: [String],
-  comments: [CommentSchema],
+  comments: [commentSchema],
   created_time: { type: Date, required: true, default: Date.now },
   detail: { type: String, required: true },
   followers: [{ type: Schema.Types.ObjectId, ref: 'User' }],
@@ -51,12 +51,12 @@ const PinSchema = new Schema({
   tags: [String],
   updated_time: { type: Date, required: true, default: Date.now },
   videos: [Schema.Types.ObjectId],
-  voters: [VoteSchema],
+  voters: [voteSchema],
 });
 
 // Index geosearch field
-PinSchema.index({ location: '2dsphere' });
+pinSchema.index({ location: '2dsphere' });
 
-const Model = mongoose.model('Pin', PinSchema);
+const Pin = mongoose.model('Pin', pinSchema);
 
-module.exports = Model;
+module.exports = Pin;

--- a/src/services/summary/summary-model.js
+++ b/src/services/summary/summary-model.js
@@ -2,7 +2,7 @@ const mongoose = require('mongoose');
 
 const Schema = mongoose.Schema;
 
-const SummarySchema = new Schema({
+const summarySchema = new Schema({
   organization: { type: String, required: true },
   date: {
     type: String,
@@ -23,8 +23,8 @@ const SummarySchema = new Schema({
   updatedAt: { type: Date, default: Date.now },
 });
 
-SummarySchema.index({ organization: 1, date: 1 }, { unique: true });
+summarySchema.index({ organization: 1, date: 1 }, { unique: true });
 
-const Model = mongoose.model('Summary', SummarySchema);
+const Summary = mongoose.model('Summary', summarySchema);
 
-module.exports = Model;
+module.exports = Summary;

--- a/src/services/user/user-model.js
+++ b/src/services/user/user-model.js
@@ -5,17 +5,17 @@ const USER = require('../../constants/roles').USER;
 
 const Schema = mongoose.Schema;
 
-const OrgRolePairSchema = new Schema({
+const orgRolePairSchema = new Schema({
   organization: { type: Schema.Types.ObjectId, ref: 'Organization' },
   role: { type: String },
 });
 
-const OrgDepartmentPairSchema = new Schema({
+const orgDepartmentPairSchema = new Schema({
   organization: { type: Schema.Types.ObjectId, ref: 'Organization' },
   department: { type: Schema.Types.ObjectId, ref: 'Department' },
 });
 
-const UserSchema = new Schema({
+const userSchema = new Schema({
   name: { type: String, required: true },
   email: {
     type: String,
@@ -32,8 +32,8 @@ const UserSchema = new Schema({
       message: '{VALUE} is not a valid phone number!',
     },
   },
-  organization_and_role_pairs: [OrgRolePairSchema],
-  organization_and_department_pairs: [OrgDepartmentPairSchema],
+  organization_and_role_pairs: [orgRolePairSchema],
+  organization_and_department_pairs: [orgDepartmentPairSchema],
   created_time: { type: Date, default: Date.now },
   updated_time: { type: Date, default: Date.now },
   customer_app_id: [Schema.Types.ObjectId],
@@ -41,6 +41,6 @@ const UserSchema = new Schema({
   owner_app_id: [Schema.Types.ObjectId],
 });
 
-const Model = mongoose.model('User', UserSchema);
+const User = mongoose.model('User', userSchema);
 
-module.exports = Model;
+module.exports = User;

--- a/src/services/video/video-model.js
+++ b/src/services/video/video-model.js
@@ -4,12 +4,12 @@ require('mongoose-type-url');
 const Schema = mongoose.Schema;
 const Url = mongoose.SchemaTypes.Url;
 
-const VideoSchema = new Schema({
+const videoSchema = new Schema({
   url: { type: Url, required: true },
   mimetype: { type: String, required: true },
   size: { type: Number, required: true },
 });
 
-const VideoModel = mongoose.model('Video', VideoSchema);
+const Video = mongoose.model('Video', videoSchema);
 
-module.exports = VideoModel;
+module.exports = Video;

--- a/test/services/department/index.test.js
+++ b/test/services/department/index.test.js
@@ -5,9 +5,9 @@ const loadFixture = require('../../test_helper').loadFixture;
 const request = require('supertest-as-promised');
 
 // Models
-const DepartmentModel = require('../../../src/services/department/department-model');
-const OrganizationModel = require('../../../src/services/organization/organization-model');
-const UserModel = require('../../../src/services/user/user-model');
+const Department = require('../../../src/services/department/department-model');
+const Organization = require('../../../src/services/organization/organization-model');
+const User = require('../../../src/services/user/user-model');
 
 // Fixtures
 const departments = require('../../fixtures/departments');
@@ -29,10 +29,10 @@ describe('department service', () => {
     server.once('listening', () => {
       // Create admin user and app3rd for admin
       Promise.all([
-        loadFixture(UserModel, superAdminUser),
-        loadFixture(UserModel, organizationAdminUser),
-        loadFixture(OrganizationModel, organizations),
-        loadFixture(DepartmentModel, departments),
+        loadFixture(User, superAdminUser),
+        loadFixture(User, organizationAdminUser),
+        loadFixture(Organization, organizations),
+        loadFixture(Department, departments),
       ])
       .then(() => {
         done();
@@ -46,9 +46,9 @@ describe('department service', () => {
   after((done) => {
     // Clear collections after finishing all tests.
     Promise.all([
-      UserModel.remove({}),
-      DepartmentModel.remove({}),
-      OrganizationModel.remove({}),
+      User.remove({}),
+      Department.remove({}),
+      Organization.remove({}),
     ])
     .then(() => {
       server.close((err) => {

--- a/test/services/organization/index.test.js
+++ b/test/services/organization/index.test.js
@@ -5,8 +5,8 @@ const loadFixture = require('../../test_helper').loadFixture;
 const request = require('supertest-as-promised');
 
 // Models
-const UserModel = require('../../../src/services/user/user-model');
-const OrganizationModel = require('../../../src/services/organization/organization-model');
+const User = require('../../../src/services/user/user-model');
+const Organization = require('../../../src/services/organization/organization-model');
 
 // Fixtures
 const adminUser = require('../../fixtures/admin_user');
@@ -27,9 +27,9 @@ describe('organization service', () => {
     server.once('listening', () => {
       // Create admin user and app3rd for admin
       Promise.all([
-        loadFixture(UserModel, superAdminUser),
-        loadFixture(UserModel, adminUser),
-        loadFixture(OrganizationModel, organizations),
+        loadFixture(User, superAdminUser),
+        loadFixture(User, adminUser),
+        loadFixture(Organization, organizations),
       ])
       .then(() => {
         done();
@@ -43,8 +43,8 @@ describe('organization service', () => {
   after((done) => {
     // Clear collections after finishing all tests.
     Promise.all([
-      UserModel.remove({}),
-      OrganizationModel.remove({}),
+      User.remove({}),
+      Organization.remove({}),
     ])
     .then(() => {
       server.close((err) => {

--- a/test/services/photo/index.test.js
+++ b/test/services/photo/index.test.js
@@ -6,8 +6,8 @@ const request = require('supertest-as-promised');
 const stub = require('../../test_helper').stub;
 
 // Models
-const PhotoModel = require('../../../src/services/photo/photo-model');
-const UserModel = require('../../../src/services/user/user-model');
+const Photo = require('../../../src/services/photo/photo-model');
+const User = require('../../../src/services/user/user-model');
 
 // Fixtures
 const adminUser = require('../../fixtures/admin_user');
@@ -29,8 +29,8 @@ describe('photo service', () => {
     server.once('listening', () => {
       // Create admin user and app3rd for admin
       Promise.all([
-        loadFixture(UserModel, adminUser),
-        loadFixture(PhotoModel, photos),
+        loadFixture(User, adminUser),
+        loadFixture(Photo, photos),
       ])
       .then(() => {
         done();
@@ -44,8 +44,8 @@ describe('photo service', () => {
   after((done) => {
     // Clear collections after finishing all tests.
     Promise.all([
-      UserModel.remove({}),
-      PhotoModel.remove({}),
+      User.remove({}),
+      Photo.remove({}),
     ])
     .then(() => {
       server.close((err) => {
@@ -143,7 +143,7 @@ describe('photo service', () => {
           expect(body.size).to.equal(4434);
 
           // Check file metadata is inserted into database
-          PhotoModel.findById(body.id, (error, photo) => {
+          Photo.findById(body.id, (error, photo) => {
             if (error) return done(error);
 
             expect(photo).to.be.ok();

--- a/test/services/pin-state-transition/index.test.js
+++ b/test/services/pin-state-transition/index.test.js
@@ -5,9 +5,9 @@ const loadFixture = require('../../test_helper').loadFixture;
 const request = require('supertest-as-promised');
 
 // Models
-const DepartmentModel = require('../../../src/services/department/department-model');
-const PinModel = require('../../../src/services/pin/pin-model');
-const UserModel = require('../../../src/services/user/user-model');
+const Department = require('../../../src/services/department/department-model');
+const Pin = require('../../../src/services/pin/pin-model');
+const User = require('../../../src/services/user/user-model');
 
 // Fixture
 const departmentHeadUser = require('../../fixtures/department_head_user');
@@ -48,11 +48,11 @@ describe('Pin state transtion service', () => {
     server.once('listening', () => {
       // Create admin user and app3rd for admin
       Promise.all([
-        loadFixture(DepartmentModel, departments),
-        loadFixture(UserModel, superAdminUser),
-        loadFixture(UserModel, organizationAdminUser),
-        loadFixture(UserModel, departmentHeadUser),
-        loadFixture(PinModel, pins),
+        loadFixture(Department, departments),
+        loadFixture(User, superAdminUser),
+        loadFixture(User, organizationAdminUser),
+        loadFixture(User, departmentHeadUser),
+        loadFixture(Pin, pins),
       ])
       .then(() => {
         done();
@@ -66,9 +66,9 @@ describe('Pin state transtion service', () => {
   after((done) => {
     // Clear collections after finishing all tests.
     Promise.all([
-      UserModel.remove({}),
-      PinModel.remove({}),
-      DepartmentModel.remove({}),
+      User.remove({}),
+      Pin.remove({}),
+      Department.remove({}),
     ])
     .then(() => {
       server.close((err) => {
@@ -239,7 +239,7 @@ describe('Pin state transtion service', () => {
       pin._id = ObjectId('579334c75563625d62811111'); // eslint-disable-line no-underscore-dangle,new-cap,max-len
       pin.status = 'verified';
 
-      new PinModel(pin).save((err, savedPin) => {
+      new Pin(pin).save((err, savedPin) => {
         if (err) {
           return done(err);
         }
@@ -269,7 +269,7 @@ describe('Pin state transtion service', () => {
           expect(transition.status).to.equal('unverified');
           expect(transition.pinId).to.equal(String(savedPin._id)); // eslint-disable-line no-underscore-dangle,max-len
 
-          return PinModel.findOne({ _id: savedPin._id }); // eslint-disable-line no-underscore-dangle,max-len
+          return Pin.findOne({ _id: savedPin._id }); // eslint-disable-line no-underscore-dangle,max-len
         })
         .then(updatedPin => {
           expect(updatedPin.status).to.equal('unverified');
@@ -283,7 +283,7 @@ describe('Pin state transtion service', () => {
       pin._id = ObjectId('579334c75563625d62811112'); // eslint-disable-line no-underscore-dangle,new-cap,max-len
       pin.status = 'unverified';
 
-      new PinModel(pin).save((err, savedPin) => {
+      new Pin(pin).save((err, savedPin) => {
         if (err) {
           return done(err);
         }
@@ -313,7 +313,7 @@ describe('Pin state transtion service', () => {
           expect(transition.status).to.equal('verified');
           expect(transition.pinId).to.equal(String(savedPin._id)); // eslint-disable-line no-underscore-dangle,max-len
 
-          return PinModel.findOne({ _id: savedPin._id }); // eslint-disable-line no-underscore-dangle,max-len
+          return Pin.findOne({ _id: savedPin._id }); // eslint-disable-line no-underscore-dangle,max-len
         })
         .then(updatedPin => {
           expect(updatedPin.status).to.equal('verified');
@@ -327,7 +327,7 @@ describe('Pin state transtion service', () => {
       pin._id = ObjectId('579334c75563625d62811113'); // eslint-disable-line no-underscore-dangle,new-cap,max-len
       pin.status = 'unverified';
 
-      new PinModel(pin).save((err, savedPin) => {
+      new Pin(pin).save((err, savedPin) => {
         if (err) {
           return done(err);
         }
@@ -357,7 +357,7 @@ describe('Pin state transtion service', () => {
           expect(transition.status).to.equal('rejected');
           expect(transition.pinId).to.equal(String(savedPin._id)); // eslint-disable-line no-underscore-dangle,max-len
 
-          return PinModel.findOne({ _id: savedPin._id }); // eslint-disable-line no-underscore-dangle,max-len
+          return Pin.findOne({ _id: savedPin._id }); // eslint-disable-line no-underscore-dangle,max-len
         })
         .then(updatedPin => {
           expect(updatedPin.status).to.equal('rejected');
@@ -371,7 +371,7 @@ describe('Pin state transtion service', () => {
       pin._id = ObjectId('579334c75563625d62811114'); // eslint-disable-line no-underscore-dangle,new-cap,max-len
       pin.status = 'unverified';
 
-      new PinModel(pin).save((err, savedPin) => {
+      new Pin(pin).save((err, savedPin) => {
         if (err) {
           return done(err);
         }
@@ -403,7 +403,7 @@ describe('Pin state transtion service', () => {
           expect(transition.assigned_department).to.equal('57933111556362511181ccc1');
           expect(transition.pinId).to.equal(String(savedPin._id)); // eslint-disable-line no-underscore-dangle,max-len
 
-          return PinModel.findOne({ _id: savedPin._id }); // eslint-disable-line no-underscore-dangle,max-len
+          return Pin.findOne({ _id: savedPin._id }); // eslint-disable-line no-underscore-dangle,max-len
         })
         .then(updatedPin => {
           expect(updatedPin.status).to.equal('assigned');
@@ -418,7 +418,7 @@ describe('Pin state transtion service', () => {
       pin._id = ObjectId('579334c75563625d62811115'); // eslint-disable-line no-underscore-dangle,new-cap,max-len
       pin.status = 'assigned';
 
-      new PinModel(pin).save((err, savedPin) => {
+      new Pin(pin).save((err, savedPin) => {
         if (err) {
           return done(err);
         }
@@ -450,7 +450,7 @@ describe('Pin state transtion service', () => {
           expect(transition.processed_by).to.equal('579334c75553625d6281b6cc');
           expect(transition.pinId).to.equal(String(savedPin._id)); // eslint-disable-line no-underscore-dangle,max-len
 
-          return PinModel.findOne({ _id: savedPin._id }); // eslint-disable-line no-underscore-dangle,max-len
+          return Pin.findOne({ _id: savedPin._id }); // eslint-disable-line no-underscore-dangle,max-len
         })
         .then(updatedPin => {
           expect(updatedPin.status).to.equal('processing');
@@ -465,7 +465,7 @@ describe('Pin state transtion service', () => {
       pin._id = ObjectId('579334c75563625d62811116'); // eslint-disable-line no-underscore-dangle,new-cap,max-len
       pin.status = 'processing';
 
-      new PinModel(pin).save((err, savedPin) => {
+      new Pin(pin).save((err, savedPin) => {
         if (err) {
           return done(err);
         }
@@ -495,7 +495,7 @@ describe('Pin state transtion service', () => {
           expect(transition.status).to.equal('resolved');
           expect(transition.pinId).to.equal(String(savedPin._id)); // eslint-disable-line no-underscore-dangle,max-len
 
-          return PinModel.findOne({ _id: savedPin._id }); // eslint-disable-line no-underscore-dangle,max-len
+          return Pin.findOne({ _id: savedPin._id }); // eslint-disable-line no-underscore-dangle,max-len
         })
         .then(updatedPin => {
           expect(updatedPin.status).to.equal('resolved');

--- a/test/services/pin/index.test.js
+++ b/test/services/pin/index.test.js
@@ -6,9 +6,9 @@ const loadFixture = require('../../test_helper').loadFixture;
 const request = require('supertest-as-promised');
 
 // Models
-const App3rdModel = require('../../../src/services/app3rd/app3rd-model');
-const PinModel = require('../../../src/services/pin/pin-model');
-const UserModel = require('../../../src/services/user/user-model');
+const App3rd = require('../../../src/services/app3rd/app3rd-model');
+const Pin = require('../../../src/services/pin/pin-model');
+const User = require('../../../src/services/user/user-model');
 
 // Fixtures
 const adminApp3rd = require('../../fixtures/admin_app3rd');
@@ -31,9 +31,9 @@ describe('pin service', () => {
     server.once('listening', () => {
       // Create admin user and app3rd for admin
       Promise.all([
-        loadFixture(UserModel, adminUser),
-        loadFixture(App3rdModel, adminApp3rd),
-        loadFixture(PinModel, pins),
+        loadFixture(User, adminUser),
+        loadFixture(App3rd, adminApp3rd),
+        loadFixture(Pin, pins),
       ])
       .then(() => {
         done();
@@ -47,9 +47,9 @@ describe('pin service', () => {
   after((done) => {
     // Clear collections after finishing all tests.
     Promise.all([
-      UserModel.remove({}),
-      PinModel.remove({}),
-      App3rdModel.remove({}),
+      User.remove({}),
+      Pin.remove({}),
+      App3rd.remove({}),
     ])
     .then(() => {
       server.close((err) => {

--- a/test/services/searchnearby/index.test.js
+++ b/test/services/searchnearby/index.test.js
@@ -4,8 +4,8 @@ const expect = require('../../test_helper').expect;
 const loadFixture = require('../../test_helper').loadFixture;
 
 // Models
-const UserModel = require('../../../src/services/user/user-model');
-const PinModel = require('../../../src/services/pin/pin-model');
+const User = require('../../../src/services/user/user-model');
+const Pin = require('../../../src/services/pin/pin-model');
 const request = require('supertest-as-promised');
 
 // Fixtures
@@ -25,8 +25,8 @@ describe('searchnearby service', () => {
     server = app.listen(app.get('port'));
     server.once('listening', () => {
       Promise.all([
-        loadFixture(UserModel, adminUser),
-        loadFixture(PinModel, pins),
+        loadFixture(User, adminUser),
+        loadFixture(Pin, pins),
       ])
       .then(() => {
         done();
@@ -37,8 +37,8 @@ describe('searchnearby service', () => {
   after((done) => {
     // Clears collection after finishing all tests.
     Promise.all([
-      PinModel.remove({}),
-      UserModel.remove({}),
+      Pin.remove({}),
+      User.remove({}),
     ])
     .then(() => {
       // Close the server

--- a/test/services/summary/index.test.js
+++ b/test/services/summary/index.test.js
@@ -6,7 +6,7 @@ const loadFixture = require('../../test_helper').loadFixture;
 const request = require('supertest-as-promised');
 
 // Models
-const ActivityLogModel = require('../../../src/services/activity-log/activity-log-model');
+const ActivityLog = require('../../../src/services/activity-log/activity-log-model');
 
 // Fixture
 const activityLogs = require('../../fixtures/activity_logs');
@@ -25,7 +25,7 @@ describe('summary service', () => {
     server = app.listen(app.get('port'));
     server.once('listening', () => {
       // Load activity log fixture
-      loadFixture(ActivityLogModel, activityLogs)
+      loadFixture(ActivityLog, activityLogs)
       .then(() => {
         done();
       })
@@ -37,7 +37,7 @@ describe('summary service', () => {
 
   after((done) => {
     // Clear collections after finishing all tests.
-    ActivityLogModel.remove({})
+    ActivityLog.remove({})
     .then(() => {
       server.close((err) => {
         if (err) return done(err);

--- a/test/services/user/index.test.js
+++ b/test/services/user/index.test.js
@@ -6,8 +6,8 @@ const loadFixture = require('../../test_helper').loadFixture;
 const request = require('supertest-as-promised');
 
 // Models
-const App3rdModel = require('../../../src/services/app3rd/app3rd-model');
-const UserModel = require('../../../src/services/user/user-model');
+const App3rd = require('../../../src/services/app3rd/app3rd-model');
+const User = require('../../../src/services/user/user-model');
 
 // Fixtures
 const adminApp3rd = require('../../fixtures/admin_app3rd');
@@ -26,8 +26,8 @@ describe('user service', () => {
     server = app.listen(app.get('port'));
     server.once('listening', () => {
       Promise.all([
-        loadFixture(UserModel, adminUser),
-        loadFixture(App3rdModel, adminApp3rd),
+        loadFixture(User, adminUser),
+        loadFixture(App3rd, adminApp3rd),
       ])
       .then(() => {
         done();
@@ -41,8 +41,8 @@ describe('user service', () => {
   after((done) => {
     // Clear all collections after finishing all tests.
     Promise.all([
-      UserModel.remove({}),
-      App3rdModel.remove({}),
+      User.remove({}),
+      App3rd.remove({}),
     ])
     .then(() => {
       // Close the server

--- a/test/services/video/index.test.js
+++ b/test/services/video/index.test.js
@@ -6,8 +6,8 @@ const request = require('supertest-as-promised');
 const stub = require('../../test_helper').stub;
 
 // Models
-const VideoModel = require('../../../src/services/video/video-model');
-const UserModel = require('../../../src/services/user/user-model');
+const Video = require('../../../src/services/video/video-model');
+const User = require('../../../src/services/user/user-model');
 
 // Fixtures
 const adminUser = require('../../fixtures/admin_user');
@@ -29,8 +29,8 @@ describe('Video service', () => {
     server.once('listening', () => {
       // Create admin user and app3rd for admin
       Promise.all([
-        loadFixture(UserModel, adminUser),
-        loadFixture(VideoModel, videos),
+        loadFixture(User, adminUser),
+        loadFixture(Video, videos),
       ])
       .then(() => {
         done();
@@ -44,8 +44,8 @@ describe('Video service', () => {
   after((done) => {
     // Clear collections after finishing all tests.
     Promise.all([
-      UserModel.remove({}),
-      VideoModel.remove({}),
+      User.remove({}),
+      Video.remove({}),
     ])
     .then(() => {
       server.close((err) => {
@@ -143,7 +143,7 @@ describe('Video service', () => {
           expect(body.size).to.equal(349612);
 
           // Check file metadata is inserted into database
-          VideoModel.findById(body.id, (error, video) => {
+          Video.findById(body.id, (error, video) => {
             if (error) return done(error);
 
             expect(video).to.be.ok();


### PR DESCRIPTION
Fix coding convention of Schema and Model to be consistency in all files.

- Use lowerCase for Schema instance. Ex. `videoSchema`.
- Use UpperCase for Model name when registering with mongoose. Ex. `mongoose.model('Video')`
- Use UpperCase and don't use suffix `Model` for Model class variable which is returned from mongoose. Ex. `const Video = mongoose.model('Video')`

Ref: http://mongoosejs.com/docs/guide.html

Example
``` javascript
const videoSchema = new Schema({
  url: { type: Url, required: true },
  mimetype: { type: String, required: true },
  size: { type: Number, required: true },
});
const Video = mongoose.model('Video', videoSchema);
```