### PR TITLE
Remove organization field from department model

### DIFF
--- a/src/services/department/department-model.js
+++ b/src/services/department/department-model.js
@@ -6,7 +6,6 @@ const departmentSchema = new Schema({
   created_time: { type: Date, default: Date.now },
   detail: { type: String },
   name: { type: String, required: true },
-  organization: { type: Schema.Types.ObjectId, ref: 'Organization', required: true },
   updated_time: { type: Date, default: Date.now },
 });
 

--- a/test/fixtures/departments.js
+++ b/test/fixtures/departments.js
@@ -2,19 +2,16 @@ const ObjectId = require('mongoose').Types.ObjectId;
 
 const DEPARTMENT_GENERAL_ID = require('./constants').DEPARTMENT_GENERAL_ID;
 const DEPARTMENT_SUPER_ADMIN_ID = require('./constants').DEPARTMENT_SUPER_ADMIN_ID;
-const ORGANIZATION_ID = require('./constants').ORGANIZATION_ID;
 
 module.exports = [
   {
     _id: ObjectId(DEPARTMENT_SUPER_ADMIN_ID), // eslint-disable-line new-cap
     name: 'Admin Department',
-    organization: ORGANIZATION_ID,
     detail: 'Admins live here',
   },
   {
     _id: ObjectId(DEPARTMENT_GENERAL_ID), // eslint-disable-line new-cap
     name: 'Department of Nerds',
-    organization: ORGANIZATION_ID,
     detail: 'An awesome department',
   },
 ];

--- a/test/services/department/index.test.js
+++ b/test/services/department/index.test.js
@@ -6,13 +6,11 @@ const request = require('supertest-as-promised');
 
 // Models
 const Department = require('../../../src/services/department/department-model');
-const Organization = require('../../../src/services/organization/organization-model');
 const User = require('../../../src/services/user/user-model');
 
 // Fixtures
 const departments = require('../../fixtures/departments');
 const organizationAdminUser = require('../../fixtures/organization_admin_user');
-const organizations = require('../../fixtures/organizations');
 const superAdminUser = require('../../fixtures/super_admin_user');
 
 // App stuff
@@ -31,7 +29,6 @@ describe('department service', () => {
       Promise.all([
         loadFixture(User, superAdminUser),
         loadFixture(User, organizationAdminUser),
-        loadFixture(Organization, organizations),
         loadFixture(Department, departments),
       ])
       .then(() => {
@@ -48,7 +45,6 @@ describe('department service', () => {
     Promise.all([
       User.remove({}),
       Department.remove({}),
-      Organization.remove({}),
     ])
     .then(() => {
       server.close((err) => {
@@ -67,7 +63,6 @@ describe('department service', () => {
     it('return 401 (unauthorized) if user is not authenticated', (done) => {
       const newDepartment = {
         name: 'YouPin',
-        organization: organizations[0]._id, // eslint-disable-line no-underscore-dangle
         detail: 'An awesome department', // eslint-disable-line no-underscore-dangle
       };
 
@@ -91,7 +86,6 @@ describe('department service', () => {
     it('return 201 when posting by super admin user', (done) => {
       const newDepartment = {
         name: 'YouPin',
-        organization: organizations[0]._id, // eslint-disable-line no-underscore-dangle
         detail: 'An awesome department', // eslint-disable-line no-underscore-dangle
       };
 
@@ -118,7 +112,7 @@ describe('department service', () => {
             .then((res) => {
               const createddepartment = res.body;
               expect(createddepartment).to.contain.keys(
-                ['_id', 'name', 'detail', 'organization',
+                ['_id', 'name', 'detail',
                   'updated_time', 'created_time']);
               done();
             });
@@ -128,7 +122,6 @@ describe('department service', () => {
     it('return 201 when posting by organization admin user', (done) => {
       const newDepartment = {
         name: 'YouPin',
-        organization: organizations[0]._id, // eslint-disable-line no-underscore-dangle
         detail: 'An awesome department', // eslint-disable-line no-underscore-dangle
       };
 
@@ -155,7 +148,7 @@ describe('department service', () => {
             .then((res) => {
               const createddepartment = res.body;
               expect(createddepartment).to.contain.keys(
-                ['_id', 'name', 'detail', 'organization',
+                ['_id', 'name', 'detail',
                   'updated_time', 'created_time']);
               done();
             });


### PR DESCRIPTION
Due to removing multiple organizations concept from the system, we need to remove the organization field from department model.