### PR TITLE
Fix error from notification steps

### DIFF
--- a/src/services/pin/hooks/index.js
+++ b/src/services/pin/hooks/index.js
@@ -1,8 +1,8 @@
 const auth = require('feathers-authentication').hooks;
 
-const assignRelatedUsersToBeNotified = require('./assign-related-users-to-be-notified');
 const logActivity = require('../../../utils/hooks/log-activity');
 const prepareActivityLog = require('./prepare-activity-log');
+const prepareNotifInfoForCreatedPin = require('./prepare-notif-info-for-created-pin');
 const restrictToOwnerOfPin = require('../../../utils/hooks/restrict-to-owner-of-pin-hook');
 const restrictToTheRightUserForUpdate = require('./restrict-to-the-right-user-for-update');
 const sendNotifToRelatedUsers = require('../../../utils/hooks/send-notif-to-related-users');
@@ -22,7 +22,6 @@ exports.before = {
     auth.populateUser(),
     auth.restrictToAuthenticated(),
     restrictToOwnerOfPin(),
-    assignRelatedUsersToBeNotified(),
   ],
   update: [
     auth.verifyToken(),
@@ -51,6 +50,7 @@ exports.after = {
   find: [],
   get: [],
   create: [
+    prepareNotifInfoForCreatedPin(),
     sendNotifToRelatedUsers(),
   ],
   update: [],

--- a/src/services/pin/hooks/prepare-notif-info-for-created-pin.js
+++ b/src/services/pin/hooks/prepare-notif-info-for-created-pin.js
@@ -3,8 +3,12 @@ const ORGANIZATION_ADMIN = require('../../../constants/roles').ORGANIZATION_ADMI
 
 // We assign related department/roles/users to be notified here which will
 // get processed again in after hook by sendNotifToRelatedUsers()
-const assignRelatedUsersToBeNotified = () => (hook) => {
+const prepareNotifInfoForCreatedPin = () => (hook) => {
   hook.data.toBeNotifiedRoles = [ORGANIZATION_ADMIN]; // eslint-disable-line no-param-reassign
+  hook.data.logInfo = { // eslint-disable-line no-param-reassign
+    description: 'A new pin is created.',
+    pin_id: hook.result._id, // eslint-disable-line no-underscore-dangle
+  };
 };
 
-module.exports = assignRelatedUsersToBeNotified;
+module.exports = prepareNotifInfoForCreatedPin;


### PR DESCRIPTION
Due to the following errors:
```
1.) ✓ return 201 when posting by authenticated user, using correct owner id, and filling all required fields (142ms)
(node:9505) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 9): Error: TypeError: Cannot read property 'description' of undefined

2.) ✓ updates correct properties for assigned transtion (131ms)
(node:9505) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 13): Error: Error: getaddrinfo ENOTFOUND your your:80
```

The cause of the problem for 1) is there was no 'description' logInfo for created pin.
I fixed it in this PR. For the cause of 2), I think it is because I throw out errors in hook. I removed it out. Since we don't want anything to fail because of just email notification.

If the notification failed to send, let it just put error out only in console so that we can check in logs later.


I also adjusted the null check logic a bit by adding more checks and moved config check to the beginning.