### PR TITLE
Allow location to be undefined.

### DIFF
--- a/src/services/pin/pin-model.js
+++ b/src/services/pin/pin-model.js
@@ -1,17 +1,8 @@
-const feathers = require('feathers');
-const configuration = require('feathers-configuration');
 const mongoose = require('mongoose');
 
 const PENDING = require('../../constants/pin-states').PENDING;
-const DEFAULT_LAT_LONG = require('../../constants/defaults').DEFAULT_LAT_LONG;
 
 const Schema = mongoose.Schema;
-
-// Read config file
-const conf = configuration('../../../');
-const app = feathers().configure(conf);
-// Fallback if default location is not set in config file
-const defaultLocation = app.get('default').location || DEFAULT_LAT_LONG;
 
 const voteSchema = new Schema({
   user_id: { type: Schema.Types.ObjectId, required: true, ref: 'User' },
@@ -46,10 +37,10 @@ const pinSchema = new Schema({
   is_merged: { type: Boolean, default: false },
   level: String,
   location: {
-    type: { type: String, enum: 'Point', default: 'Point' },
+    type: { type: String },
     coordinates: {
-      type: [Number],
-      default: [defaultLocation.long, defaultLocation.lat],
+      type: [],
+      index: '2dsphere',
     },
   },
   mentions: [{ type: Schema.Types.ObjectId, ref: 'User' }],
@@ -75,7 +66,6 @@ const pinSchema = new Schema({
   voters: [voteSchema],
 });
 
-// Index geosearch field
 pinSchema.index({ location: '2dsphere' });
 
 pinSchema.pre('find', function populateFields(next) {

--- a/test/fixtures/pins.js
+++ b/test/fixtures/pins.js
@@ -27,6 +27,7 @@ module.exports = [
     owner: USER_ADMIN_ID, // adminUser ObjectId
     provider: USER_ADMIN_ID, // adminUser ObjectId
     location: {
+      type: 'Point',
       coordinates: [100.56983534303, 13.730537951109],
     },
     status: state.PENDING,
@@ -42,6 +43,7 @@ module.exports = [
     owner: USER_ADMIN_ID, // adminUser ObjectId
     provider: USER_ADMIN_ID, // adminUser ObjectId
     location: {
+      type: 'Point',
       coordinates: [100.56983534305, 13.730537951107],
     },
     assigned_users: [USER_DEPARTMENT_HEAD_ID],
@@ -58,6 +60,7 @@ module.exports = [
     owner: USER_ADMIN_ID, // adminUser ObjectId
     provider: USER_ADMIN_ID, // adminUser ObjectId
     location: {
+      type: 'Point',
       coordinates: [100.56983534305, 13.730537951107],
     },
     processing_time: '2015-12-04',
@@ -82,6 +85,7 @@ module.exports = [
     owner: USER_ADMIN_ID, // adminUser ObjectId
     provider: USER_ADMIN_ID, // adminUser ObjectId
     location: {
+      type: 'Point',
       coordinates: [100.56983534305, 13.730537951107],
     },
     processing_time: '2015-12-04',
@@ -105,6 +109,7 @@ module.exports = [
     owner: USER_ADMIN_ID, // adminUser ObjectId
     provider: USER_ADMIN_ID, // adminUser ObjectId
     location: {
+      type: 'Point',
       coordinates: [100.56983534305, 13.730537951107],
     },
     status: state.REJECTED,

--- a/test/services/pin/post.test.js
+++ b/test/services/pin/post.test.js
@@ -36,7 +36,6 @@ const { PENDING, ASSIGNED } = require('../../../src/constants/pin-states');
 
 // App stuff
 const app = require('../../../src/app');
-const DEFAULT_LAT_LONG = require('../../../src/constants/defaults').DEFAULT_LAT_LONG;
 
 // Exit test if NODE_ENV is not equal `test`
 assertTestEnv();
@@ -158,6 +157,7 @@ describe('Pin - POST', () => {
       owner: adminUser._id, // eslint-disable-line no-underscore-dangle
       provider: adminUser._id, // eslint-disable-line no-underscore-dangle
       location: {
+        type: 'Point',
         coordinates: [10.733626, 10.5253153],
       },
     };
@@ -198,6 +198,7 @@ describe('Pin - POST', () => {
       owner: adminUser._id, // eslint-disable-line no-underscore-dangle
       provider: adminUser._id, // eslint-disable-line no-underscore-dangle
       location: {
+        type: 'Point',
         coordinates: [10.733626, 10.5253153],
       },
     };
@@ -233,6 +234,7 @@ describe('Pin - POST', () => {
       owner: adminUser._id, // eslint-disable-line no-underscore-dangle
       provider: adminUser._id, // eslint-disable-line no-underscore-dangle
       location: {
+        type: 'Point',
         coordinates: [10.733626, 10.5253153],
       },
       status: ASSIGNED,
@@ -273,7 +275,6 @@ describe('Pin - POST', () => {
       organization: ORGANIZATION_ID,
       owner: adminUser._id, // eslint-disable-line no-underscore-dangle
       provider: adminUser._id, // eslint-disable-line no-underscore-dangle
-      location: {},
     };
 
     login(app, 'contact@youpin.city', 'youpin_admin')
@@ -294,7 +295,7 @@ describe('Pin - POST', () => {
           .then((res) => {
             const createdPin = res.body;
             expect(createdPin.status).to.equal(PENDING);
-            expect(createdPin.location.coordinates).to.deep.equal(DEFAULT_LAT_LONG);
+            expect(createdPin.location).to.be.undefined();
             done();
           });
       });


### PR DESCRIPTION
Due to the bug https://github.com/Automattic/mongoose/issues/1668, we need to make schema w/o type and explicitly declare it when using instead.